### PR TITLE
fix: Filter video tracks by active video track.

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -35,6 +35,7 @@ goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.net.NetworkingUtils');
 goog.require('shaka.text.Cue');
+goog.require('shaka.text.NativeTextDisplayer');
 goog.require('shaka.text.SimpleTextDisplayer');
 goog.require('shaka.text.StubTextDisplayer');
 goog.require('shaka.text.TextEngine');
@@ -228,6 +229,10 @@ goog.requireType('shaka.media.PresentationTimeline');
  *   the MediaSource successfully.
  * @property {string} type
  *   'boundarycrossed'
+ * @property {boolean} oldEncrypted
+ *   True when the old boundary is encrypted.
+ * @property {boolean} newEncrypted
+ *   True when the new boundary is encrypted.
  * @exportDoc
  */
 
@@ -380,6 +385,25 @@ goog.requireType('shaka.media.PresentationTimeline');
  * @property {boolean} isLive
  *   True when the playlist is live. Useful to detect transition from live
  *   to static playlist..
+ * @exportDoc
+ */
+
+
+/**
+ * @event shaka.Player.MetadataAddedEvent
+ * @description Triggers when metadata associated with the stream is added.
+ * @property {string} type
+ *   'metadataadded'
+ * @property {number} startTime
+ *   The time that describes the beginning of the range of the metadata to
+ *   which the cue applies.
+ * @property {?number} endTime
+ *   The time that describes the end of the range of the metadata to which
+ *   the cue applies.
+ * @property {string} metadataType
+ *   Type of metadata. Eg: 'org.id3' or 'com.apple.quicktime.HLS'
+ * @property {shaka.extern.MetadataFrame} payload
+ *   The metadata itself
  * @exportDoc
  */
 
@@ -775,7 +799,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {?string} */
     this.mimeType_ = null;
 
-    /** @private {?number} */
+    /** @private {?number|Date} */
     this.startTime_ = null;
 
     /** @private {boolean} */
@@ -882,10 +906,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.cmsdManager_ = this.createCmsd_();
 
     this.networkingEngine_ = this.createNetworkingEngine();
-    this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
-    this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
-    this.networkingEngine_.setMinBytesForProgressEvents(
-        this.config_.streaming.minBytesForProgressEvents);
 
     /** @private {shaka.extern.IAdManager} */
     this.adManager_ = null;
@@ -898,6 +918,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     /** @private {boolean} */
     this.preloadDueAdManagerVideoEnded_ = false;
+
+    /** @private {!Array<HTMLTrackElement>} */
+    this.externalSrcEqualsTextTracks_ = [];
 
     /** @private {shaka.util.Timer} */
     this.preloadDueAdManagerTimer_ = new shaka.util.Timer(async () => {
@@ -1510,8 +1533,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
 
       if (this.video_) {
-        // Remove all track nodes
-        shaka.util.Dom.removeAllChildren(this.video_);
+        // The life cycle of tracks that created by addTextTrackAsync() and
+        // their associated resources should be the same as the loaded video.
+        for (const trackNode of this.externalSrcEqualsTextTracks_) {
+          if (trackNode.src.startsWith('blob:')) {
+            URL.revokeObjectURL(trackNode.src);
+          }
+          trackNode.remove();
+        }
+        this.externalSrcEqualsTextTracks_ = [];
 
         // In order to unload a media element, we need to remove the src
         // attribute and then load again. When we destroy media source engine,
@@ -1519,8 +1549,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         //
         // DrmEngine requires this to be done before we destroy DrmEngine
         // itself.
-        if (this.video_.src) {
-          this.video_.removeAttribute('src');
+        if (shaka.util.Dom.clearSourceFromVideo(this.video_)) {
           this.video_.load();
         }
       }
@@ -1601,7 +1630,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * event handler to update the start position based on information in the
    * manifest.
    *
-   * @param {number} startTime
+   * @param {number|Date} startTime
    * @export
    */
   updateStartTime(startTime) {
@@ -1613,7 +1642,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * If another stream was already playing, first unloads that stream.
    *
    * @param {string|shaka.media.PreloadManager} assetUriOrPreloader
-   * @param {?number=} startTime
+   * @param {?number|Date=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2024,7 +2053,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * asset must be played with src=, which cannot be preloaded.
    *
    * @param {string} assetUri
-   * @param {?number=} startTime
+   * @param {?number|Date=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2063,7 +2092,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @param {?string=} mimeType
    * @param {boolean=} standardLoad
    * @return {!Promise<?shaka.media.PreloadManager>}
@@ -2121,7 +2150,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @param {?string} mimeType
    * @param {boolean=} allowPrefetch
    * @param {boolean=} disableVideo
@@ -2498,8 +2527,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.makeStateChangeEvent_('media-source');
 
     // Remove children if we had any, i.e. from previously used src= mode.
-    this.video_.removeAttribute('src');
-    shaka.util.Dom.removeAllChildren(this.video_);
+    if (this.config_.mediaSource.useSourceElements) {
+      shaka.util.Dom.clearSourceFromVideo(this.video_);
+    }
 
     this.createTextDisplayer_();
     goog.asserts.assert(this.textDisplayer_,
@@ -2518,8 +2548,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           onEvent: (event) => this.dispatchEvent(event),
           onManifestUpdate: () => this.onManifestUpdate_(),
         },
-        this.lcevcDec_);
-    mediaSourceEngine.configure(this.config_.mediaSource);
+        this.lcevcDec_,
+        this.config_.mediaSource);
     const {segmentRelativeVttTiming} = this.config_.manifest;
     mediaSourceEngine.setSegmentRelativeVttTiming(segmentRelativeVttTiming);
 
@@ -2546,8 +2576,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.loadEventManager_.listen(mediaElement, 'ended', updateStateHistory);
     this.loadEventManager_.listen(mediaElement, 'ratechange', onRateChange);
     if (mediaElement.remote) {
-      this.loadEventManager_.listen(mediaElement.remote, 'connect',
-          () => this.onTracksChanged_());
+      this.loadEventManager_.listen(mediaElement.remote, 'connect', () => {
+        if (this.streamingEngine_ &&
+            mediaElement.remote.state == 'connected') {
+          this.onTextChanged_();
+        }
+        this.onTracksChanged_();
+      });
       this.loadEventManager_.listen(mediaElement.remote, 'connecting',
           () => this.onTracksChanged_());
       this.loadEventManager_.listen(mediaElement.remote, 'disconnect',
@@ -2555,6 +2590,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             if (this.streamingEngine_ &&
                 mediaElement.remote.state == 'disconnected') {
               await this.streamingEngine_.resetMediaSource();
+              this.onTextChanged_();
             }
             this.onTracksChanged_();
           });
@@ -2567,8 +2603,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.loadEventManager_.listen(mediaElement.audioTracks, 'change',
           () => this.onTracksChanged_());
     }
+    if (mediaElement.videoTracks) {
+      this.loadEventManager_.listen(mediaElement.videoTracks, 'addtrack',
+          () => this.onTracksChanged_());
+      this.loadEventManager_.listen(mediaElement.videoTracks, 'removetrack',
+          () => this.onTracksChanged_());
+      this.loadEventManager_.listen(mediaElement.videoTracks, 'change',
+          () => this.onTracksChanged_());
+    }
 
     if (mediaElement.textTracks) {
+      const trackChange = () => {
+        if (this.loadMode_ === shaka.Player.LoadMode.SRC_EQUALS &&
+            this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer) {
+          this.onTextChanged_();
+        }
+        this.onTracksChanged_();
+      };
       this.loadEventManager_.listen(
           mediaElement.textTracks, 'addtrack', (e) => {
             const trackEvent = /** @type {!TrackEvent} */(e);
@@ -2587,15 +2638,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                   break;
 
                 default:
-                  this.onTracksChanged_();
+                  trackChange();
                   break;
               }
             }
           });
       this.loadEventManager_.listen(mediaElement.textTracks, 'removetrack',
-          () => this.onTracksChanged_());
+          trackChange);
       this.loadEventManager_.listen(mediaElement.textTracks, 'change',
-          () => this.onTracksChanged_());
+          trackChange);
 
       if (this.config_.streaming.crossBoundaryStrategy !==
         shaka.config.CrossBoundaryStrategy.KEEP) {
@@ -2783,7 +2834,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // align to a segment boundary.
       if (this.config_.streaming.startAtSegmentBoundary) {
         const timeline = this.manifest_.presentationTimeline;
-        let initialTime = this.startTime_ || this.video_.currentTime;
+        let initialTime;
+        if (this.startTime_ instanceof Date) {
+          const presentationStartTime = timeline.getInitialProgramDateTime() ||
+              timeline.getPresentationStartTime();
+          goog.asserts.assert(presentationStartTime != null,
+              'Presentation start time should not be null!');
+          const time = (this.startTime_.getTime() / 1000.0) -
+              presentationStartTime;
+          if (time != null) {
+            initialTime = time;
+          }
+        }
+        if (initialTime == null) {
+          initialTime = typeof this.startTime_ === 'number' ? this.startTime_ :
+              this.video_.currentTime;
+        }
         if (this.startTime_ == null && this.manifest_.startTime) {
           initialTime = this.manifest_.startTime;
         }
@@ -3069,55 +3135,43 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (mediaElement.textTracks) {
       this.createTextDisplayer_();
-      const setShowingMode = () => {
-        const track = this.getFilteredTextTracks_()
-            .find((t) => t.mode !== 'disabled');
-        if (track) {
-          track.mode = 'showing';
-        }
-        const generatedTrack = this.getGeneratedTextTrack_();
-        if (generatedTrack) {
-          generatedTrack.mode = 'hidden';
-        }
-      };
-      const setHiddenMode = () => {
-        const track = this.getFilteredTextTracks_()
-            .find((t) => t.mode !== 'disabled');
-        if (track) {
-          track.mode = 'hidden';
-        }
-        const generatedTrack = this.getGeneratedTextTrack_();
-        const isTextVisible = this.textDisplayer_.isTextVisible();
-        if (generatedTrack && isTextVisible) {
-          generatedTrack.mode = 'showing';
+      const setMode = (showing) => {
+        if (!(this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer)) {
+          const track = this.getFilteredTextTracks_()
+              .find((t) => t.mode !== 'disabled');
+          if (track) {
+            track.mode = showing ? 'showing' : 'hidden';
+          }
+          if (this.textDisplayer_ instanceof shaka.text.SimpleTextDisplayer) {
+            const generatedTrack = this.getGeneratedTextTrack_();
+            if (generatedTrack) {
+              generatedTrack.mode =
+                !showing && this.textDisplayer_.isTextVisible() ?
+                'showing' : 'hidden';
+            }
+          }
         }
       };
       this.loadEventManager_.listen(mediaElement, 'enterpictureinpicture',
-          () => setShowingMode());
+          () => setMode(true));
       this.loadEventManager_.listen(mediaElement, 'leavepictureinpicture',
-          () => setHiddenMode());
+          () => setMode(false));
       if (mediaElement.remote) {
         this.loadEventManager_.listen(mediaElement.remote, 'connect',
-            () => setHiddenMode());
+            () => setMode(false));
         this.loadEventManager_.listen(mediaElement.remote, 'connecting',
-            () => setHiddenMode());
+            () => setMode(false));
         this.loadEventManager_.listen(mediaElement.remote, 'disconnect',
-            () => setHiddenMode());
+            () => setMode(false));
       } else if ('webkitCurrentPlaybackTargetIsWireless' in mediaElement) {
         this.loadEventManager_.listen(mediaElement,
             'webkitcurrentplaybacktargetiswirelesschanged',
-            () => setHiddenMode());
+            () => setMode(false));
       }
       const video = /** @type {HTMLVideoElement} */(mediaElement);
       if (video.webkitSupportsFullscreen) {
         this.loadEventManager_.listen(video, 'webkitpresentationmodechanged',
-            () => {
-              if (video.webkitPresentationMode != 'inline') {
-                setShowingMode();
-              } else {
-                setHiddenMode();
-              }
-            });
+            () => setMode(video.webkitPresentationMode !== 'inline'));
       }
     }
     // Add all media element listeners.
@@ -3144,7 +3198,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       await this.mediaSourceEngine_.destroy();
       this.mediaSourceEngine_ = null;
     }
-    shaka.util.Dom.removeAllChildren(mediaElement);
+    shaka.util.Dom.clearSourceFromVideo(mediaElement);
 
     mediaElement.src = playbackUri;
 
@@ -3221,27 +3275,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.textDisplayer_.setTextVisibility(true);
           }
 
-          if (textTracks.length) {
-            if (this.textDisplayer_.enableTextDisplayer) {
-              this.textDisplayer_.enableTextDisplayer();
-            } else {
-              shaka.Deprecate.deprecateFeature(5,
-                  'Text displayer w/ enableTextDisplayer',
-                  'Text displayer should have a "enableTextDisplayer" method!');
-            }
-          }
-
-          let enabledNativeTrack = false;
-          for (const track of textTracks) {
-            if (track.mode !== 'disabled') {
-              if (!enabledNativeTrack) {
-                this.enableNativeTrack_(track);
-                enabledNativeTrack = true;
+          if (
+            !(this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer)
+          ) {
+            if (textTracks.length) {
+              if (this.textDisplayer_.enableTextDisplayer) {
+                this.textDisplayer_.enableTextDisplayer();
               } else {
-                track.mode = 'disabled';
-                shaka.log.alwaysWarn(
-                    'Found more than one enabled text track, disabling it',
-                    track);
+                shaka.Deprecate.deprecateFeature(
+                    5,
+                    'Text displayer w/ enableTextDisplayer',
+                    'Text displayer should have a "enableTextDisplayer" method',
+                );
+              }
+            }
+
+            let enabledNativeTrack = false;
+            for (const track of textTracks) {
+              if (track.mode !== 'disabled') {
+                if (!enabledNativeTrack) {
+                  this.enableNativeTrack_(track);
+                  enabledNativeTrack = true;
+                } else {
+                  track.mode = 'disabled';
+                  shaka.log.alwaysWarn(
+                      'Found more than one enabled text track, disabling it',
+                      track);
+                }
               }
             }
           }
@@ -3502,6 +3562,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // JSON stringify produces a good ID in this case.
     region.id = JSON.stringify(region);
     this.metadataRegionTimeline_.addRegion(region);
+    const data = new Map()
+        .set('startTime', region.startTime)
+        .set('endTime', region.endTime)
+        .set('metadataType', region.schemeIdUri)
+        .set('payload', region.payload);
+    this.dispatchEvent(shaka.Player.makeEvent_(
+        shaka.util.FakeEvent.EventName.MetadataAdded, data));
   }
 
   /**
@@ -3635,14 +3702,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     };
     /** @type {shaka.net.NetworkingEngine.onProgressUpdated} */
     const onProgressUpdated_ = (deltaTimeMs,
-        bytesDownloaded, allowSwitch, request) => {
+        bytesDownloaded, allowSwitch, request, context) => {
       // In some situations, such as during offline storage, the abr manager
       // might not yet exist. Therefore, we need to check if abr manager has
       // been initialized before using it.
       const abrManager = getAbrManager();
       if (abrManager) {
         abrManager.segmentDownloaded(deltaTimeMs, bytesDownloaded,
-            allowSwitch, request);
+            allowSwitch, request, context);
       }
     };
     /** @type {shaka.net.NetworkingEngine.OnHeadersReceived} */
@@ -3709,16 +3776,18 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     };
 
-    return new shaka.net.NetworkingEngine(
+    const networkingEngine = new shaka.net.NetworkingEngine(
         onProgressUpdated_, onHeadersReceived_, onDownloadCompleted_,
         onDownloadFailed_, onRequest_, onRetry_, onResponse_);
+    networkingEngine.configure(this.config_.networking);
+    return networkingEngine;
   }
 
   /**
    * Creates a new instance of Playhead.  This can be replaced by tests to
    * create fake instances instead.
    *
-   * @param {?number} startTime
+   * @param {?number|Date} startTime
    * @return {!shaka.media.Playhead}
    */
   createPlayhead(startTime) {
@@ -3737,7 +3806,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Create the observers for MSE playback. These observers are responsible for
    * notifying the app and player of specific events during MSE playback.
    *
-   * @param {number} startTime
+   * @param {number|Date} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3750,7 +3819,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have emsg region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = this.isLive() || startTime > 0;
+    const startsPastZero = this.isLive() ||
+        (typeof startTime === 'number' && startTime > 0);
 
     // Create the region observer. This will allow us to notify the app when we
     // move in and out of timeline regions.
@@ -3828,7 +3898,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * responsible for notifying the app and player of specific events during src
    * equals playback.
    *
-   * @param {number} startTime
+   * @param {number|!Date} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3837,7 +3907,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have metadata region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = startTime > 0;
+    const startsPastZero = startTime instanceof Date || startTime > 0;
 
     /**
      * @type {!shaka.media.RegionObserver<
@@ -3977,15 +4047,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {!shaka.extern.TextDisplayer} textDisplayer
    * @param {!shaka.media.MediaSourceEngine.PlayerInterface} playerInterface
    * @param {shaka.lcevc.Dec} lcevcDec
+   * @param {shaka.extern.MediaSourceConfiguration} config
    *
    * @return {!shaka.media.MediaSourceEngine}
    */
   createMediaSourceEngine(mediaElement, textDisplayer, playerInterface,
-      lcevcDec) {
+      lcevcDec, config) {
     return new shaka.media.MediaSourceEngine(
         mediaElement,
         textDisplayer,
         playerInterface,
+        config,
         lcevcDec);
   }
 
@@ -4106,6 +4178,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmuxTS configuration',
           'Please Use mediaSource.forceTransmux instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmuxTS'];
       delete config['streaming']['forceTransmuxTS'];
@@ -4116,6 +4189,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmux configuration',
           'Please Use mediaSource.forceTransmux instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmux'];
       delete config['streaming']['forceTransmux'];
@@ -4289,6 +4363,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.dispatchAllEmsgBoxes configuration',
           'Please Use mediaSource.dispatchAllEmsgBoxes instead.');
+      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['dispatchAllEmsgBoxes'] =
           config['streaming']['dispatchAllEmsgBoxes'];
       delete config['streaming']['dispatchAllEmsgBoxes'];
@@ -4390,6 +4465,38 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
 
+    // Deprecate 'streaming.forceHTTP' configuration.
+    if (config['streaming'] && 'forceHTTP' in config['streaming']) {
+      shaka.Deprecate.deprecateFeature(5,
+          'streaming.forceHTTP configuration',
+          'Please Use networking.forceHTTP instead.');
+      config['networking'] = config['networking'] || {};
+      config['networking']['forceHTTP'] = config['streaming']['forceHTTP'];
+      delete config['streaming']['forceHTTP'];
+    }
+
+    // Deprecate 'streaming.forceHTTPS' configuration.
+    if (config['streaming'] && 'forceHTTPS' in config['streaming']) {
+      shaka.Deprecate.deprecateFeature(5,
+          'streaming.forceHTTPS configuration',
+          'Please Use networking.forceHTTP instead.');
+      config['networking'] = config['networking'] || {};
+      config['networking']['forceHTTPS'] = config['streaming']['forceHTTPS'];
+      delete config['streaming']['forceHTTPS'];
+    }
+
+    // Deprecate 'streaming.minBytesForProgressEvents' configuration.
+    if (config['streaming'] &&
+        'minBytesForProgressEvents' in config['streaming']) {
+      shaka.Deprecate.deprecateFeature(5,
+          'streaming.minBytesForProgressEvents configuration',
+          'Please Use networking.minBytesForProgressEvents instead.');
+      config['networking'] = config['networking'] || {};
+      config['networking']['minBytesForProgressEvents'] =
+          config['streaming']['minBytesForProgressEvents'];
+      delete config['streaming']['minBytesForProgressEvents'];
+    }
+
     // Enforce inaccurateManifestTolerance: 0 when using crossBoundaryStrategy
     // different from KEEP.
     if (config['streaming'] && 'crossBoundaryStrategy' in config['streaming']) {
@@ -4469,10 +4576,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
     if (this.networkingEngine_) {
-      this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
-      this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
-      this.networkingEngine_.setMinBytesForProgressEvents(
-          this.config_.streaming.minBytesForProgressEvents);
+      this.networkingEngine_.configure(this.config_.networking);
     }
 
     if (this.mediaSourceEngine_) {
@@ -5088,12 +5192,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           activeTracks++;
           currentVideoId = track.videoId;
         }
+
         tracks.push(track);
       }
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
-      
+
       if (!currentVideoId) {
         return tracks;
       } else {
@@ -5106,13 +5211,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         return currentVideoTracks;
       }
     } else if (this.video_ && this.video_.audioTracks) {
+      const videoTrack = this.getActiveHtml5VideoTrack_();
       // Safari's native HLS always shows a single element in videoTracks.
       // You can't use that API to change resolutions.  But we can use
       // audioTracks to generate a variant list that is usable for changing
       // languages.
       const audioTracks = Array.from(this.video_.audioTracks);
-      return audioTracks.map((audio) =>
-        shaka.util.StreamUtils.html5AudioTrackToTrack(audio));
+      if (audioTracks.length) {
+        return audioTracks.map((audio) =>
+          shaka.util.StreamUtils.html5TrackToShakaTrack(audio, videoTrack));
+      } else if (videoTrack) {
+        return [
+          shaka.util.StreamUtils.html5TrackToShakaTrack(null, videoTrack),
+        ];
+      } else {
+        return [];
+      }
     } else {
       return [];
     }
@@ -5124,24 +5238,28 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * <p>
    * If the player has not loaded content, this will return an empty list.
    *
-   * @return {!Array<shaka.extern.Track>}
+   * @return {!Array<shaka.extern.TextTrack>}
    * @export
    */
   getTextTracks() {
-    if (this.manifest_ && !this.isRemotePlayback()) {
-      const currentTextStream = this.streamingEngine_ ?
+    if (this.manifest_) {
+      if (this.isRemotePlayback()) {
+        return [];
+      } else {
+        const currentTextStream = this.streamingEngine_ ?
           this.streamingEngine_.getCurrentTextStream() : null;
-      const tracks = [];
+        const tracks = [];
 
-      // Convert all selectable text streams to tracks.
-      for (const text of this.manifest_.textStreams) {
-        const track = shaka.util.StreamUtils.textStreamToTrack(text);
-        track.active = text == currentTextStream;
+        // Convert all selectable text streams to tracks.
+        for (const text of this.manifest_.textStreams) {
+          const track = shaka.util.StreamUtils.textStreamToTrack(text);
+          track.active = text == currentTextStream;
 
-        tracks.push(track);
+          tracks.push(track);
+        }
+
+        return tracks;
       }
-
-      return tracks;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const StreamUtils = shaka.util.StreamUtils;
@@ -5156,7 +5274,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * If the player has not loaded content, this will return an empty list.
    *
-   * @return {!Array<shaka.extern.Track>}
+   * @return {!Array<shaka.extern.ImageTrack>}
    * @export
    */
   getImageTracks() {
@@ -5354,6 +5472,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       startTime: thumbnailTime,
       duration: thumbnailDuration,
       uris: reference.getUris(),
+      startByte: reference.getStartByte(),
+      endByte: reference.getEndByte(),
       width: width,
       sprite: sprite,
       mimeType: reference.mimeType || imageStream.mimeType,
@@ -5370,7 +5490,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Note that <code>AdaptationEvents</code> are not fired for manual track
    * selections.
    *
-   * @param {shaka.extern.Track} track
+   * @param {shaka.extern.TextTrack} track
    * @export
    */
   selectTextTrack(track) {
@@ -5405,22 +5525,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const selectSrcEqualsMode = () => {
       if (this.video_ && this.video_.textTracks) {
         const textTracks = this.getFilteredTextTracks_();
-        const oldTrack = textTracks.find((textTrack) =>
-          textTrack.mode !== 'disabled');
         const newTrack = textTracks.find((textTrack) =>
           shaka.util.StreamUtils.html5TrackId(textTrack) === track.id);
         if (!newTrack) {
           shaka.log.error('No track with id', track.id);
           return;
         }
-        if (oldTrack !== newTrack) {
-          if (oldTrack) {
-            oldTrack.mode = 'disabled';
-            this.loadEventManager_.unlisten(oldTrack, 'cuechange');
-            this.textDisplayer_.remove(0, Infinity);
+        if (this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer) {
+          for (const texTrack of textTracks) {
+            const mode = texTrack === newTrack ?
+                this.isTextVisible_ ? 'showing' : 'hidden' :
+                'disabled';
+            if (texTrack.mode !== mode) {
+              texTrack.mode = mode;
+            }
           }
-          if (newTrack) {
-            this.enableNativeTrack_(newTrack);
+        } else {
+          const oldTrack = textTracks.find((textTrack) =>
+            textTrack.mode !== 'disabled');
+          if (oldTrack !== newTrack) {
+            if (oldTrack) {
+              oldTrack.mode = 'disabled';
+              this.loadEventManager_.unlisten(oldTrack, 'cuechange');
+              this.textDisplayer_.remove(0, Infinity);
+            }
+            if (newTrack) {
+              this.enableNativeTrack_(newTrack);
+            }
           }
         }
         this.onTextChanged_();
@@ -5574,6 +5705,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.updateAbrManagerVariants_();
     };
     const selectSrcEqualsMode = () => {
+      if (!track.originalAudioId) {
+        return;
+      }
       if (this.video_ && this.video_.audioTracks) {
         // Safari's native HLS won't let you choose an explicit variant, though
         // you can choose audio languages this way.
@@ -5696,6 +5830,105 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     return Array.from(audioTracksMap.values());
   }
 
+
+  /**
+   * Select a video track compatible with the current audio track.
+   * If the player has not loaded any content, this will be a no-op.
+   *
+   * @param {shaka.extern.VideoTrack} videoTrack
+   * @param {boolean=} clearBuffer
+   * @param {number=} safeMargin Optional amount of buffer (in seconds) to
+   *   retain when clearing the buffer. Useful for switching quickly
+   *   without causing a buffering event. Defaults to 0 if not provided. Can
+   *   cause hiccups on some browsers if chosen too small, e.g. The amount of
+   *   two segments is a fair minimum to consider as safeMargin value.
+   * @export
+   */
+  selectVideoTrack(videoTrack, clearBuffer = false, safeMargin = 0) {
+    const variants = this.getVariantTracks();
+    if (!variants.length) {
+      return;
+    }
+    const active = variants.find((t) => t.active);
+    if (!active) {
+      return;
+    }
+    const validVariant = variants.find((t) => {
+      return t.audioId === active.audioId &&
+          (t.videoBandwidth || t.bandwidth) == videoTrack.bandwidth &&
+          t.width == videoTrack.width &&
+          t.height == videoTrack.height &&
+          t.frameRate == videoTrack.frameRate &&
+          t.pixelAspectRatio == videoTrack.pixelAspectRatio &&
+          t.hdr == videoTrack.hdr &&
+          t.colorGamut == videoTrack.colorGamut &&
+          t.videoLayout == videoTrack.videoLayout &&
+          t.videoMimeType == videoTrack.mimeType &&
+          t.videoCodec == videoTrack.codecs;
+    });
+    if (validVariant && !validVariant.active) {
+      this.selectVariantTrack(validVariant, clearBuffer, safeMargin);
+    }
+  }
+
+
+  /**
+   * Return a list of video tracks compatible with the current audio track.
+   *
+   * @return {!Array<shaka.extern.VideoTrack>}
+   * @export
+   */
+  getVideoTracks() {
+    if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
+      return [];
+    }
+    const variants = this.getVariantTracks();
+    if (!variants.length) {
+      return [];
+    }
+    const active = variants.find((t) => t.active);
+    if (!active) {
+      return [];
+    }
+    const filteredTracks = variants.filter((t) => {
+      return t.originalAudioId === active.originalAudioId &&
+          t.audioId === active.audioId &&
+          t.audioGroupId === active.audioGroupId &&
+          t.videoCodec;
+    });
+    if (!filteredTracks.length) {
+      return [];
+    }
+
+    /** @type {!Map<string, shaka.extern.VideoTrack>} */
+    const videoTracksMap = new Map();
+    for (const track of filteredTracks) {
+      let id = track.originalVideoId;
+      if (!id && track.videoId != null) {
+        id = String(track.videoId);
+      }
+      if (!id) {
+        continue;
+      }
+      /** @type {shaka.extern.VideoTrack} */
+      const videoTrack = {
+        active: track.active,
+        bandwidth: track.videoBandwidth || track.bandwidth,
+        width: track.width,
+        height: track.height,
+        frameRate: track.frameRate,
+        pixelAspectRatio: track.pixelAspectRatio,
+        hdr: track.hdr,
+        colorGamut: track.colorGamut,
+        videoLayout: track.videoLayout,
+        mimeType: track.videoMimeType,
+        codecs: track.videoCodec,
+      };
+      videoTracksMap.set(id, videoTrack);
+    }
+    return Array.from(videoTracksMap.values());
+  }
+
   /**
    * Return a list of audio language-role combinations available.  If the
    * player has not loaded any content, this will return an empty list.
@@ -5717,7 +5950,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Return a list of text language-role combinations available.  If the player
    * has not loaded any content, this will be return an empty list.
    *
+   * <br>
+   *
+   * This API is deprecated and will be removed in version 5.0, please migrate
+   * to using `getTextTracks` and `selectTextTrack`.
+   *
    * @return {!Array<shaka.extern.LanguageRole>}
+   * @deprecated
    * @export
    */
   getTextLanguagesAndRoles() {
@@ -5745,7 +5984,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Return a list of text languages available. If the player has not loaded
    * any content, this will return an empty list.
    *
+   * <br>
+   *
+   * This API is deprecated and will be removed in version 5.0, please migrate
+   * to using `getTextTracks` and `selectTextTrack`.
+   *
    * @return {!Array<string>}
+   * @deprecated
    * @export
    */
   getTextLanguages() {
@@ -5856,9 +6101,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * language and role, and chooses a new variant if need be. If the player has
    * not loaded any content, this will be a no-op.
    *
+   * <br>
+   *
+   * This API is deprecated and will be removed in version 5.0, please migrate
+   * to using `getTextTracks` and `selectTextTrack`.
+   *
    * @param {string} language
    * @param {string=} role
    * @param {boolean=} forced
+   * @deprecated
    * @export
    */
   selectTextLanguage(language, role, forced = false) {
@@ -6008,7 +6259,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Return a list of chapters tracks.
    *
-   * @return {!Array<shaka.extern.Track>}
+   * @return {!Array<shaka.extern.TextTrack>}
    * @export
    */
   getChaptersTracks() {
@@ -6024,6 +6275,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   getChapters(language) {
+    shaka.Deprecate.deprecateFeature(5,
+        'getChapters',
+        'Please use an getChaptersAsync.');
     if (!this.externalChaptersStreams_.length) {
       return [];
     }
@@ -6054,6 +6308,50 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           }
         });
       }
+    }
+    return chapters;
+  }
+
+  /**
+   * This returns the list of chapters.
+   *
+   * @param {string} language
+   * @return {!Promise<!Array<shaka.extern.Chapter>>}
+   * @export
+   */
+  async getChaptersAsync(language) {
+    if (!this.externalChaptersStreams_.length) {
+      return [];
+    }
+    const LanguageUtils = shaka.util.LanguageUtils;
+    const inputLanguage = LanguageUtils.normalize(language);
+    const chapterStreams = this.externalChaptersStreams_
+        .filter((c) => LanguageUtils.normalize(c.language) == inputLanguage);
+    if (!chapterStreams.length) {
+      return [];
+    }
+    const chapters = [];
+    const uniqueChapters = new Set();
+    for (const chapterStream of chapterStreams) {
+      if (!chapterStream.segmentIndex) {
+        // eslint-disable-next-line no-await-in-loop
+        await chapterStream.createSegmentIndex();
+      }
+      chapterStream.segmentIndex.forEachTopLevelReference((ref) => {
+        const title = ref.getUris()[0];
+        const id = ref.startTime + '-' + ref.endTime + '-' + title;
+        /** @type {shaka.extern.Chapter} */
+        const chapter = {
+          id,
+          title,
+          startTime: ref.startTime,
+          endTime: ref.endTime,
+        };
+        if (!uniqueChapters.has(id)) {
+          chapters.push(chapter);
+          uniqueChapters.add(id);
+        }
+      });
     }
     return chapters;
   }
@@ -6175,6 +6473,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // would start at the live edge, but we don't have that yet, so return
       // the current date & time.
       return new Date();
+    } else if (this.startTime_ instanceof Date) {
+      // A specific start time as a Date has been requested.  Return it without
+      // any modification.
+      return this.startTime_;
     } else {
       // A specific start time has been requested.  This is what Playhead will
       // use once it is created.
@@ -6345,35 +6647,53 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.drmEngine_ ? this.drmEngine_.getLicenseTime() : NaN;
     this.stats_.setLicenseTime(licenseSeconds);
 
-    if (this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE) {
-      // Event through we are loaded, it is still possible that we don't have a
-      // variant yet because we set the load mode before we select the first
-      // variant to stream.
-      const variant = this.streamingEngine_.getCurrentVariant();
-      const textStream = this.streamingEngine_.getCurrentTextStream();
+    // Resolution fallback
+    this.stats_.setResolution(
+        /* width= */ element.videoWidth || NaN,
+        /* height= */ element.videoHeight || NaN);
 
-      if (variant) {
+    this.stats_.setCodecs('');
+
+    if (this.isLive()) {
+      // Apple's native HLS gives us getStartDate(), which is only available
+      // if EXT-X-PROGRAM-DATETIME is in the playlist.
+      if (this.getPresentationStartTimeAsDate() != null) {
+        const latency = this.getLiveLatency() || 0;
+        this.stats_.setLiveLatency(latency / 1000);
+      }
+    }
+
+    const variants = this.getVariantTracks();
+    const variant = variants.find((t) => t.active);
+    const textTracks = this.getTextTracks();
+    const textTrack = textTracks.find((t) => t.active);
+    if (variant) {
+      if (variant.bandwidth) {
         const rate = this.playRateController_ ?
            this.playRateController_.getRealRate() : 1;
         const variantBandwidth = rate * variant.bandwidth;
         let currentStreamBandwidth = variantBandwidth;
-        if (textStream && textStream.bandwidth) {
-          currentStreamBandwidth += (rate * textStream.bandwidth);
+        if (textTrack && textTrack.bandwidth) {
+          currentStreamBandwidth += (rate * textTrack.bandwidth);
         }
         this.stats_.setCurrentStreamBandwidth(currentStreamBandwidth);
       }
-
-      if (variant && variant.video) {
+      if (variant.width && variant.height) {
         this.stats_.setResolution(
-            /* width= */ variant.video.width || NaN,
-            /* height= */ variant.video.height || NaN);
+            /* width= */ variant.width || NaN,
+            /* height= */ variant.height || NaN);
       }
-
-      if (this.isLive()) {
-        const latency = this.getLiveLatency() || 0;
-        this.stats_.setLiveLatency(latency / 1000);
+      let codecs = variant.codecs;
+      if (textTrack) {
+        codecs += ',' + (textTrack.codecs || textTrack.mimeType);
       }
+      if (codecs) {
+        this.stats_.setCodecs(codecs);
+      }
+    }
 
+    if (this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE &&
+        !this.isRemotePlayback()) {
       if (this.manifest_) {
         this.stats_.setManifestPeriodCount(this.manifest_.periodCount);
         this.stats_.setManifestGapCount(this.manifest_.gapCount);
@@ -6390,9 +6710,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
       this.stats_.addBytesDownloaded(NaN);
-      this.stats_.setResolution(
-          /* width= */ element.videoWidth || NaN,
-          /* height= */ element.videoHeight || NaN);
     }
 
     return this.stats_.getBlob();
@@ -6412,7 +6729,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string=} codec
    * @param {string=} label
    * @param {boolean=} forced
-   * @return {!Promise<shaka.extern.Track>}
+   * @return {!Promise<shaka.extern.TextTrack>}
    * @export
    */
   async addTextTrackAsync(uri, language, kind, mimeType, codec, label,
@@ -6444,25 +6761,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
-      if (forced) {
+      if (forced && shaka.util.Platform.isApple()) {
         // See: https://github.com/whatwg/html/issues/4472
         kind = 'forced';
       }
-      await this.addSrcTrackElement_(uri, language, kind, mimeType, label || '',
-          adCuePoints);
-
-      const LanguageUtils = shaka.util.LanguageUtils;
-      const languageNormalized = LanguageUtils.normalize(language);
-
-      const textTracks = this.getTextTracks();
-      const srcTrack = textTracks.find((t) => {
-        return LanguageUtils.normalize(t.language) == languageNormalized &&
-            t.label == (label || '') &&
-            t.kind == kind;
-      });
-      if (srcTrack) {
+      const trackNode = await this.addSrcTrackElement_(uri, language, kind,
+          mimeType, label || '', adCuePoints);
+      if (trackNode.track) {
         this.onTracksChanged_();
-        return srcTrack;
+        return shaka.util.StreamUtils.html5TextTrackToTrack(trackNode.track);
       }
       // This should not happen, but there are browser implementations that may
       // not support the Track element.
@@ -6564,7 +6871,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {string} uri
    * @param {string=} mimeType
-   * @return {!Promise<shaka.extern.Track>}
+   * @return {!Promise<shaka.extern.ImageTrack>}
    * @export
    */
   async addThumbnailsTrack(uri, mimeType) {
@@ -6725,7 +7032,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string} uri
    * @param {string} language
    * @param {string=} mimeType
-   * @return {!Promise<shaka.extern.Track>}
+   * @return {!Promise<shaka.extern.TextTrack>}
    * @export
    */
   async addChaptersTrack(uri, language, mimeType) {
@@ -6911,6 +7218,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.video_.appendChild(trackElement);
+    this.externalSrcEqualsTextTracks_.push(trackElement);
     return trackElement;
   }
 
@@ -7115,7 +7423,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // TextDisplay factory must capture a reference to "this".
     config.textDisplayFactory = () => {
       // On iOS where the Fullscreen API is not available we prefer
-      // SimpleTextDisplayer because it works with the Fullscreen API of the
+      // NativeTextDisplayer because it works with the Fullscreen API of the
       // video element itself.
       const Platform = shaka.util.Platform;
       if (this.videoContainer_ &&
@@ -7123,9 +7431,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         return new shaka.text.UITextDisplayer(
             this.video_, this.videoContainer_);
       } else {
-        if ('addTextTrack' in this.video_) {
-          return new shaka.text.SimpleTextDisplayer(
-              this.video_, shaka.Player.TextTrackLabel);
+        if ('track' in document.createElement('track')) {
+          return new shaka.text.NativeTextDisplayer(this);
         } else {
           shaka.log.warning('Text tracks are not supported by the ' +
                             'browser, disabling.');
@@ -7932,6 +8239,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   switchHtml5Track_(track) {
+    const StreamUtils = shaka.util.StreamUtils;
     goog.asserts.assert(this.video_ && this.video_.audioTracks,
         'Video and video.audioTracks should not be null!');
     const audioTracks = Array.from(this.video_.audioTracks);
@@ -7950,15 +8258,28 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       currentTrack.enabled = false;
     }
 
+    const videoTrack = this.getActiveHtml5VideoTrack_();
+
     const oldTrack =
-      shaka.util.StreamUtils.html5AudioTrackToTrack(currentTrack);
-    const newTrack =
-      shaka.util.StreamUtils.html5AudioTrackToTrack(track);
+        StreamUtils.html5TrackToShakaTrack(currentTrack, videoTrack);
+    const newTrack = StreamUtils.html5TrackToShakaTrack(track, videoTrack);
     // Dispatch a 'variantchanged' event
     this.onVariantChanged_(oldTrack, newTrack);
 
     // Dispatch a 'audiotrackschanged' event if necessary
     this.checkAudioTracksChanged_(oldTrack, newTrack);
+  }
+
+  /**
+   * @return {VideoTrack}
+   * @private
+   */
+  getActiveHtml5VideoTrack_() {
+    if (this.video_ && this.video_.videoTracks) {
+      const videoTracks = Array.from(this.video_.videoTracks);
+      return videoTracks.find((t) => t.selected);
+    }
+    return null;
   }
 
   /**
@@ -8374,33 +8695,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {string} name
    * @param {string} url
+   * @return {!Promise<void>}
    * @export
    */
-  async addFont(name, url) {
-    if ('fonts' in document && 'FontFace' in window ) {
-      await document.fonts.ready;
-      if (!('entries' in document.fonts)) {
-        return;
-      }
-      const fontFaceSetIteratorToArray = (target) => {
-        const iterable = target.entries();
-        const results = [];
-        let iterator = iterable.next();
-        while (iterator.done === false) {
-          results.push(iterator.value);
-          iterator = iterable.next();
-        }
-        return results;
-      };
-      for (const fontFace of fontFaceSetIteratorToArray(document.fonts)) {
-        if (fontFace.family == name && fontFace.display == 'swap') {
-          // Font already loaded.
-          return;
-        }
-      }
-      const fontFace = new FontFace(name, `url(${url})`, {display: 'swap'});
-      document.fonts.add(fontFace);
-    }
+  addFont(name, url) {
+    return shaka.util.Dom.addFont(name, url);
   }
 
   /**
@@ -8713,7 +9012,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Get the normalized languages for a group of tracks.
    *
-   * @param {!Array<?shaka.extern.Track>} tracks
+   * @param {!Array<?(shaka.extern.Track|shaka.extern.TextTrack)>} tracks
    * @return {!Set<string>}
    * @private
    */
@@ -8735,7 +9034,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Get all permutations of normalized languages and role for a group of
    * tracks.
    *
-   * @param {!Array<?shaka.extern.Track>} tracks
+   * @param {!Array<?(shaka.extern.Track|shaka.extern.TextTrack)>} tracks
    * @return {!Array<shaka.extern.LanguageRole>}
    * @private
    */
@@ -8745,7 +9044,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @type {!Map<string, !Map<string, string>>} */
     const languageRoleToLabel = new Map();
 
-    for (const track of tracks) {
+    for (let i = 0; i < tracks.length; i++) {
+      const track = /** @type {shaka.extern.Track} */(tracks[i]);
       let language = 'und';
       let roles = [];
 
@@ -8952,7 +9252,7 @@ shaka.Player.TYPICAL_BUFFERING_THRESHOLD_ = 0.5;
  * @export
  */
 // eslint-disable-next-line no-useless-concat
-shaka.Player.version = 'v4.14.10' + '-uncompiled';  // x-release-please-version
+shaka.Player.version = 'v4.14.0' + '-uncompiled';  // x-release-please-version
 
 // Initialize the deprecation system using the version string we just set
 // on the player.

--- a/lib/player.js
+++ b/lib/player.js
@@ -35,7 +35,6 @@ goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.net.NetworkingUtils');
 goog.require('shaka.text.Cue');
-goog.require('shaka.text.NativeTextDisplayer');
 goog.require('shaka.text.SimpleTextDisplayer');
 goog.require('shaka.text.StubTextDisplayer');
 goog.require('shaka.text.TextEngine');
@@ -229,10 +228,6 @@ goog.requireType('shaka.media.PresentationTimeline');
  *   the MediaSource successfully.
  * @property {string} type
  *   'boundarycrossed'
- * @property {boolean} oldEncrypted
- *   True when the old boundary is encrypted.
- * @property {boolean} newEncrypted
- *   True when the new boundary is encrypted.
  * @exportDoc
  */
 
@@ -385,25 +380,6 @@ goog.requireType('shaka.media.PresentationTimeline');
  * @property {boolean} isLive
  *   True when the playlist is live. Useful to detect transition from live
  *   to static playlist..
- * @exportDoc
- */
-
-
-/**
- * @event shaka.Player.MetadataAddedEvent
- * @description Triggers when metadata associated with the stream is added.
- * @property {string} type
- *   'metadataadded'
- * @property {number} startTime
- *   The time that describes the beginning of the range of the metadata to
- *   which the cue applies.
- * @property {?number} endTime
- *   The time that describes the end of the range of the metadata to which
- *   the cue applies.
- * @property {string} metadataType
- *   Type of metadata. Eg: 'org.id3' or 'com.apple.quicktime.HLS'
- * @property {shaka.extern.MetadataFrame} payload
- *   The metadata itself
  * @exportDoc
  */
 
@@ -799,7 +775,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {?string} */
     this.mimeType_ = null;
 
-    /** @private {?number|Date} */
+    /** @private {?number} */
     this.startTime_ = null;
 
     /** @private {boolean} */
@@ -906,6 +882,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.cmsdManager_ = this.createCmsd_();
 
     this.networkingEngine_ = this.createNetworkingEngine();
+    this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
+    this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
+    this.networkingEngine_.setMinBytesForProgressEvents(
+        this.config_.streaming.minBytesForProgressEvents);
 
     /** @private {shaka.extern.IAdManager} */
     this.adManager_ = null;
@@ -918,9 +898,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     /** @private {boolean} */
     this.preloadDueAdManagerVideoEnded_ = false;
-
-    /** @private {!Array<HTMLTrackElement>} */
-    this.externalSrcEqualsTextTracks_ = [];
 
     /** @private {shaka.util.Timer} */
     this.preloadDueAdManagerTimer_ = new shaka.util.Timer(async () => {
@@ -1533,15 +1510,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
 
       if (this.video_) {
-        // The life cycle of tracks that created by addTextTrackAsync() and
-        // their associated resources should be the same as the loaded video.
-        for (const trackNode of this.externalSrcEqualsTextTracks_) {
-          if (trackNode.src.startsWith('blob:')) {
-            URL.revokeObjectURL(trackNode.src);
-          }
-          trackNode.remove();
-        }
-        this.externalSrcEqualsTextTracks_ = [];
+        // Remove all track nodes
+        shaka.util.Dom.removeAllChildren(this.video_);
 
         // In order to unload a media element, we need to remove the src
         // attribute and then load again. When we destroy media source engine,
@@ -1549,7 +1519,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         //
         // DrmEngine requires this to be done before we destroy DrmEngine
         // itself.
-        if (shaka.util.Dom.clearSourceFromVideo(this.video_)) {
+        if (this.video_.src) {
+          this.video_.removeAttribute('src');
           this.video_.load();
         }
       }
@@ -1630,7 +1601,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * event handler to update the start position based on information in the
    * manifest.
    *
-   * @param {number|Date} startTime
+   * @param {number} startTime
    * @export
    */
   updateStartTime(startTime) {
@@ -1642,7 +1613,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * If another stream was already playing, first unloads that stream.
    *
    * @param {string|shaka.media.PreloadManager} assetUriOrPreloader
-   * @param {?number|Date=} startTime
+   * @param {?number=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2053,7 +2024,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * asset must be played with src=, which cannot be preloaded.
    *
    * @param {string} assetUri
-   * @param {?number|Date=} startTime
+   * @param {?number=} startTime
    *    When <code>startTime</code> is <code>null</code> or
    *    <code>undefined</code>, playback will start at the default start time (0
    *    for VOD and liveEdge for LIVE).
@@ -2092,7 +2063,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number|Date} startTime
+   * @param {?number} startTime
    * @param {?string=} mimeType
    * @param {boolean=} standardLoad
    * @return {!Promise<?shaka.media.PreloadManager>}
@@ -2150,7 +2121,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
   /**
    * @param {string} assetUri
-   * @param {?number|Date} startTime
+   * @param {?number} startTime
    * @param {?string} mimeType
    * @param {boolean=} allowPrefetch
    * @param {boolean=} disableVideo
@@ -2527,9 +2498,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.makeStateChangeEvent_('media-source');
 
     // Remove children if we had any, i.e. from previously used src= mode.
-    if (this.config_.mediaSource.useSourceElements) {
-      shaka.util.Dom.clearSourceFromVideo(this.video_);
-    }
+    this.video_.removeAttribute('src');
+    shaka.util.Dom.removeAllChildren(this.video_);
 
     this.createTextDisplayer_();
     goog.asserts.assert(this.textDisplayer_,
@@ -2548,8 +2518,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           onEvent: (event) => this.dispatchEvent(event),
           onManifestUpdate: () => this.onManifestUpdate_(),
         },
-        this.lcevcDec_,
-        this.config_.mediaSource);
+        this.lcevcDec_);
+    mediaSourceEngine.configure(this.config_.mediaSource);
     const {segmentRelativeVttTiming} = this.config_.manifest;
     mediaSourceEngine.setSegmentRelativeVttTiming(segmentRelativeVttTiming);
 
@@ -2576,13 +2546,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.loadEventManager_.listen(mediaElement, 'ended', updateStateHistory);
     this.loadEventManager_.listen(mediaElement, 'ratechange', onRateChange);
     if (mediaElement.remote) {
-      this.loadEventManager_.listen(mediaElement.remote, 'connect', () => {
-        if (this.streamingEngine_ &&
-            mediaElement.remote.state == 'connected') {
-          this.onTextChanged_();
-        }
-        this.onTracksChanged_();
-      });
+      this.loadEventManager_.listen(mediaElement.remote, 'connect',
+          () => this.onTracksChanged_());
       this.loadEventManager_.listen(mediaElement.remote, 'connecting',
           () => this.onTracksChanged_());
       this.loadEventManager_.listen(mediaElement.remote, 'disconnect',
@@ -2590,7 +2555,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             if (this.streamingEngine_ &&
                 mediaElement.remote.state == 'disconnected') {
               await this.streamingEngine_.resetMediaSource();
-              this.onTextChanged_();
             }
             this.onTracksChanged_();
           });
@@ -2603,23 +2567,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.loadEventManager_.listen(mediaElement.audioTracks, 'change',
           () => this.onTracksChanged_());
     }
-    if (mediaElement.videoTracks) {
-      this.loadEventManager_.listen(mediaElement.videoTracks, 'addtrack',
-          () => this.onTracksChanged_());
-      this.loadEventManager_.listen(mediaElement.videoTracks, 'removetrack',
-          () => this.onTracksChanged_());
-      this.loadEventManager_.listen(mediaElement.videoTracks, 'change',
-          () => this.onTracksChanged_());
-    }
 
     if (mediaElement.textTracks) {
-      const trackChange = () => {
-        if (this.loadMode_ === shaka.Player.LoadMode.SRC_EQUALS &&
-            this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer) {
-          this.onTextChanged_();
-        }
-        this.onTracksChanged_();
-      };
       this.loadEventManager_.listen(
           mediaElement.textTracks, 'addtrack', (e) => {
             const trackEvent = /** @type {!TrackEvent} */(e);
@@ -2638,15 +2587,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
                   break;
 
                 default:
-                  trackChange();
+                  this.onTracksChanged_();
                   break;
               }
             }
           });
       this.loadEventManager_.listen(mediaElement.textTracks, 'removetrack',
-          trackChange);
+          () => this.onTracksChanged_());
       this.loadEventManager_.listen(mediaElement.textTracks, 'change',
-          trackChange);
+          () => this.onTracksChanged_());
 
       if (this.config_.streaming.crossBoundaryStrategy !==
         shaka.config.CrossBoundaryStrategy.KEEP) {
@@ -2834,22 +2783,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // align to a segment boundary.
       if (this.config_.streaming.startAtSegmentBoundary) {
         const timeline = this.manifest_.presentationTimeline;
-        let initialTime;
-        if (this.startTime_ instanceof Date) {
-          const presentationStartTime = timeline.getInitialProgramDateTime() ||
-              timeline.getPresentationStartTime();
-          goog.asserts.assert(presentationStartTime != null,
-              'Presentation start time should not be null!');
-          const time = (this.startTime_.getTime() / 1000.0) -
-              presentationStartTime;
-          if (time != null) {
-            initialTime = time;
-          }
-        }
-        if (initialTime == null) {
-          initialTime = typeof this.startTime_ === 'number' ? this.startTime_ :
-              this.video_.currentTime;
-        }
+        let initialTime = this.startTime_ || this.video_.currentTime;
         if (this.startTime_ == null && this.manifest_.startTime) {
           initialTime = this.manifest_.startTime;
         }
@@ -3135,43 +3069,55 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (mediaElement.textTracks) {
       this.createTextDisplayer_();
-      const setMode = (showing) => {
-        if (!(this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer)) {
-          const track = this.getFilteredTextTracks_()
-              .find((t) => t.mode !== 'disabled');
-          if (track) {
-            track.mode = showing ? 'showing' : 'hidden';
-          }
-          if (this.textDisplayer_ instanceof shaka.text.SimpleTextDisplayer) {
-            const generatedTrack = this.getGeneratedTextTrack_();
-            if (generatedTrack) {
-              generatedTrack.mode =
-                !showing && this.textDisplayer_.isTextVisible() ?
-                'showing' : 'hidden';
-            }
-          }
+      const setShowingMode = () => {
+        const track = this.getFilteredTextTracks_()
+            .find((t) => t.mode !== 'disabled');
+        if (track) {
+          track.mode = 'showing';
+        }
+        const generatedTrack = this.getGeneratedTextTrack_();
+        if (generatedTrack) {
+          generatedTrack.mode = 'hidden';
+        }
+      };
+      const setHiddenMode = () => {
+        const track = this.getFilteredTextTracks_()
+            .find((t) => t.mode !== 'disabled');
+        if (track) {
+          track.mode = 'hidden';
+        }
+        const generatedTrack = this.getGeneratedTextTrack_();
+        const isTextVisible = this.textDisplayer_.isTextVisible();
+        if (generatedTrack && isTextVisible) {
+          generatedTrack.mode = 'showing';
         }
       };
       this.loadEventManager_.listen(mediaElement, 'enterpictureinpicture',
-          () => setMode(true));
+          () => setShowingMode());
       this.loadEventManager_.listen(mediaElement, 'leavepictureinpicture',
-          () => setMode(false));
+          () => setHiddenMode());
       if (mediaElement.remote) {
         this.loadEventManager_.listen(mediaElement.remote, 'connect',
-            () => setMode(false));
+            () => setHiddenMode());
         this.loadEventManager_.listen(mediaElement.remote, 'connecting',
-            () => setMode(false));
+            () => setHiddenMode());
         this.loadEventManager_.listen(mediaElement.remote, 'disconnect',
-            () => setMode(false));
+            () => setHiddenMode());
       } else if ('webkitCurrentPlaybackTargetIsWireless' in mediaElement) {
         this.loadEventManager_.listen(mediaElement,
             'webkitcurrentplaybacktargetiswirelesschanged',
-            () => setMode(false));
+            () => setHiddenMode());
       }
       const video = /** @type {HTMLVideoElement} */(mediaElement);
       if (video.webkitSupportsFullscreen) {
         this.loadEventManager_.listen(video, 'webkitpresentationmodechanged',
-            () => setMode(video.webkitPresentationMode !== 'inline'));
+            () => {
+              if (video.webkitPresentationMode != 'inline') {
+                setShowingMode();
+              } else {
+                setHiddenMode();
+              }
+            });
       }
     }
     // Add all media element listeners.
@@ -3198,7 +3144,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       await this.mediaSourceEngine_.destroy();
       this.mediaSourceEngine_ = null;
     }
-    shaka.util.Dom.clearSourceFromVideo(mediaElement);
+    shaka.util.Dom.removeAllChildren(mediaElement);
 
     mediaElement.src = playbackUri;
 
@@ -3275,33 +3221,27 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             this.textDisplayer_.setTextVisibility(true);
           }
 
-          if (
-            !(this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer)
-          ) {
-            if (textTracks.length) {
-              if (this.textDisplayer_.enableTextDisplayer) {
-                this.textDisplayer_.enableTextDisplayer();
-              } else {
-                shaka.Deprecate.deprecateFeature(
-                    5,
-                    'Text displayer w/ enableTextDisplayer',
-                    'Text displayer should have a "enableTextDisplayer" method',
-                );
-              }
+          if (textTracks.length) {
+            if (this.textDisplayer_.enableTextDisplayer) {
+              this.textDisplayer_.enableTextDisplayer();
+            } else {
+              shaka.Deprecate.deprecateFeature(5,
+                  'Text displayer w/ enableTextDisplayer',
+                  'Text displayer should have a "enableTextDisplayer" method!');
             }
+          }
 
-            let enabledNativeTrack = false;
-            for (const track of textTracks) {
-              if (track.mode !== 'disabled') {
-                if (!enabledNativeTrack) {
-                  this.enableNativeTrack_(track);
-                  enabledNativeTrack = true;
-                } else {
-                  track.mode = 'disabled';
-                  shaka.log.alwaysWarn(
-                      'Found more than one enabled text track, disabling it',
-                      track);
-                }
+          let enabledNativeTrack = false;
+          for (const track of textTracks) {
+            if (track.mode !== 'disabled') {
+              if (!enabledNativeTrack) {
+                this.enableNativeTrack_(track);
+                enabledNativeTrack = true;
+              } else {
+                track.mode = 'disabled';
+                shaka.log.alwaysWarn(
+                    'Found more than one enabled text track, disabling it',
+                    track);
               }
             }
           }
@@ -3562,13 +3502,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // JSON stringify produces a good ID in this case.
     region.id = JSON.stringify(region);
     this.metadataRegionTimeline_.addRegion(region);
-    const data = new Map()
-        .set('startTime', region.startTime)
-        .set('endTime', region.endTime)
-        .set('metadataType', region.schemeIdUri)
-        .set('payload', region.payload);
-    this.dispatchEvent(shaka.Player.makeEvent_(
-        shaka.util.FakeEvent.EventName.MetadataAdded, data));
   }
 
   /**
@@ -3702,14 +3635,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     };
     /** @type {shaka.net.NetworkingEngine.onProgressUpdated} */
     const onProgressUpdated_ = (deltaTimeMs,
-        bytesDownloaded, allowSwitch, request, context) => {
+        bytesDownloaded, allowSwitch, request) => {
       // In some situations, such as during offline storage, the abr manager
       // might not yet exist. Therefore, we need to check if abr manager has
       // been initialized before using it.
       const abrManager = getAbrManager();
       if (abrManager) {
         abrManager.segmentDownloaded(deltaTimeMs, bytesDownloaded,
-            allowSwitch, request, context);
+            allowSwitch, request);
       }
     };
     /** @type {shaka.net.NetworkingEngine.OnHeadersReceived} */
@@ -3776,18 +3709,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     };
 
-    const networkingEngine = new shaka.net.NetworkingEngine(
+    return new shaka.net.NetworkingEngine(
         onProgressUpdated_, onHeadersReceived_, onDownloadCompleted_,
         onDownloadFailed_, onRequest_, onRetry_, onResponse_);
-    networkingEngine.configure(this.config_.networking);
-    return networkingEngine;
   }
 
   /**
    * Creates a new instance of Playhead.  This can be replaced by tests to
    * create fake instances instead.
    *
-   * @param {?number|Date} startTime
+   * @param {?number} startTime
    * @return {!shaka.media.Playhead}
    */
   createPlayhead(startTime) {
@@ -3806,7 +3737,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Create the observers for MSE playback. These observers are responsible for
    * notifying the app and player of specific events during MSE playback.
    *
-   * @param {number|Date} startTime
+   * @param {number} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3819,8 +3750,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have emsg region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = this.isLive() ||
-        (typeof startTime === 'number' && startTime > 0);
+    const startsPastZero = this.isLive() || startTime > 0;
 
     // Create the region observer. This will allow us to notify the app when we
     // move in and out of timeline regions.
@@ -3898,7 +3828,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * responsible for notifying the app and player of specific events during src
    * equals playback.
    *
-   * @param {number|!Date} startTime
+   * @param {number} startTime
    * @return {!shaka.media.PlayheadObserverManager}
    * @private
    */
@@ -3907,7 +3837,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         'Must have metadata region timeline');
     goog.asserts.assert(this.video_, 'Must have video element');
 
-    const startsPastZero = startTime instanceof Date || startTime > 0;
+    const startsPastZero = startTime > 0;
 
     /**
      * @type {!shaka.media.RegionObserver<
@@ -4047,17 +3977,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {!shaka.extern.TextDisplayer} textDisplayer
    * @param {!shaka.media.MediaSourceEngine.PlayerInterface} playerInterface
    * @param {shaka.lcevc.Dec} lcevcDec
-   * @param {shaka.extern.MediaSourceConfiguration} config
    *
    * @return {!shaka.media.MediaSourceEngine}
    */
   createMediaSourceEngine(mediaElement, textDisplayer, playerInterface,
-      lcevcDec, config) {
+      lcevcDec) {
     return new shaka.media.MediaSourceEngine(
         mediaElement,
         textDisplayer,
         playerInterface,
-        config,
         lcevcDec);
   }
 
@@ -4178,7 +4106,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmuxTS configuration',
           'Please Use mediaSource.forceTransmux instead.');
-      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmuxTS'];
       delete config['streaming']['forceTransmuxTS'];
@@ -4189,7 +4116,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.forceTransmux configuration',
           'Please Use mediaSource.forceTransmux instead.');
-      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['mediaSource'] =
           config['streaming']['forceTransmux'];
       delete config['streaming']['forceTransmux'];
@@ -4363,7 +4289,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       shaka.Deprecate.deprecateFeature(5,
           'streaming.dispatchAllEmsgBoxes configuration',
           'Please Use mediaSource.dispatchAllEmsgBoxes instead.');
-      config['mediaSource'] = config['mediaSource'] || {};
       config['mediaSource']['dispatchAllEmsgBoxes'] =
           config['streaming']['dispatchAllEmsgBoxes'];
       delete config['streaming']['dispatchAllEmsgBoxes'];
@@ -4465,38 +4390,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
 
-    // Deprecate 'streaming.forceHTTP' configuration.
-    if (config['streaming'] && 'forceHTTP' in config['streaming']) {
-      shaka.Deprecate.deprecateFeature(5,
-          'streaming.forceHTTP configuration',
-          'Please Use networking.forceHTTP instead.');
-      config['networking'] = config['networking'] || {};
-      config['networking']['forceHTTP'] = config['streaming']['forceHTTP'];
-      delete config['streaming']['forceHTTP'];
-    }
-
-    // Deprecate 'streaming.forceHTTPS' configuration.
-    if (config['streaming'] && 'forceHTTPS' in config['streaming']) {
-      shaka.Deprecate.deprecateFeature(5,
-          'streaming.forceHTTPS configuration',
-          'Please Use networking.forceHTTP instead.');
-      config['networking'] = config['networking'] || {};
-      config['networking']['forceHTTPS'] = config['streaming']['forceHTTPS'];
-      delete config['streaming']['forceHTTPS'];
-    }
-
-    // Deprecate 'streaming.minBytesForProgressEvents' configuration.
-    if (config['streaming'] &&
-        'minBytesForProgressEvents' in config['streaming']) {
-      shaka.Deprecate.deprecateFeature(5,
-          'streaming.minBytesForProgressEvents configuration',
-          'Please Use networking.minBytesForProgressEvents instead.');
-      config['networking'] = config['networking'] || {};
-      config['networking']['minBytesForProgressEvents'] =
-          config['streaming']['minBytesForProgressEvents'];
-      delete config['streaming']['minBytesForProgressEvents'];
-    }
-
     // Enforce inaccurateManifestTolerance: 0 when using crossBoundaryStrategy
     // different from KEEP.
     if (config['streaming'] && 'crossBoundaryStrategy' in config['streaming']) {
@@ -4576,7 +4469,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       }
     }
     if (this.networkingEngine_) {
-      this.networkingEngine_.configure(this.config_.networking);
+      this.networkingEngine_.setForceHTTP(this.config_.streaming.forceHTTP);
+      this.networkingEngine_.setForceHTTPS(this.config_.streaming.forceHTTPS);
+      this.networkingEngine_.setMinBytesForProgressEvents(
+          this.config_.streaming.minBytesForProgressEvents);
     }
 
     if (this.mediaSourceEngine_) {
@@ -5172,6 +5068,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const tracks = [];
 
       let activeTracks = 0;
+      let currentVideoId = undefined;
 
       // Convert each variant to a track.
       for (const variant of this.manifest_.variants) {
@@ -5189,32 +5086,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
         if (track.active) {
           activeTracks++;
+          currentVideoId = track.videoId;
         }
-
         tracks.push(track);
       }
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
-
-      return tracks;
+      
+      if (!currentVideoId) {
+        return tracks;
+      } else {
+        const currentVideoTracks = [];
+        for (const track of tracks) {
+          if (track.videoId === currentVideoId) {
+            currentVideoTracks.push(track);
+          }
+        }
+        return currentVideoTracks;
+      }
     } else if (this.video_ && this.video_.audioTracks) {
-      const videoTrack = this.getActiveHtml5VideoTrack_();
       // Safari's native HLS always shows a single element in videoTracks.
       // You can't use that API to change resolutions.  But we can use
       // audioTracks to generate a variant list that is usable for changing
       // languages.
       const audioTracks = Array.from(this.video_.audioTracks);
-      if (audioTracks.length) {
-        return audioTracks.map((audio) =>
-          shaka.util.StreamUtils.html5TrackToShakaTrack(audio, videoTrack));
-      } else if (videoTrack) {
-        return [
-          shaka.util.StreamUtils.html5TrackToShakaTrack(null, videoTrack),
-        ];
-      } else {
-        return [];
-      }
+      return audioTracks.map((audio) =>
+        shaka.util.StreamUtils.html5AudioTrackToTrack(audio));
     } else {
       return [];
     }
@@ -5226,28 +5124,24 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * <p>
    * If the player has not loaded content, this will return an empty list.
    *
-   * @return {!Array<shaka.extern.TextTrack>}
+   * @return {!Array<shaka.extern.Track>}
    * @export
    */
   getTextTracks() {
-    if (this.manifest_) {
-      if (this.isRemotePlayback()) {
-        return [];
-      } else {
-        const currentTextStream = this.streamingEngine_ ?
+    if (this.manifest_ && !this.isRemotePlayback()) {
+      const currentTextStream = this.streamingEngine_ ?
           this.streamingEngine_.getCurrentTextStream() : null;
-        const tracks = [];
+      const tracks = [];
 
-        // Convert all selectable text streams to tracks.
-        for (const text of this.manifest_.textStreams) {
-          const track = shaka.util.StreamUtils.textStreamToTrack(text);
-          track.active = text == currentTextStream;
+      // Convert all selectable text streams to tracks.
+      for (const text of this.manifest_.textStreams) {
+        const track = shaka.util.StreamUtils.textStreamToTrack(text);
+        track.active = text == currentTextStream;
 
-          tracks.push(track);
-        }
-
-        return tracks;
+        tracks.push(track);
       }
+
+      return tracks;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
       const textTracks = this.getFilteredTextTracks_();
       const StreamUtils = shaka.util.StreamUtils;
@@ -5262,7 +5156,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * If the player has not loaded content, this will return an empty list.
    *
-   * @return {!Array<shaka.extern.ImageTrack>}
+   * @return {!Array<shaka.extern.Track>}
    * @export
    */
   getImageTracks() {
@@ -5460,8 +5354,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       startTime: thumbnailTime,
       duration: thumbnailDuration,
       uris: reference.getUris(),
-      startByte: reference.getStartByte(),
-      endByte: reference.getEndByte(),
       width: width,
       sprite: sprite,
       mimeType: reference.mimeType || imageStream.mimeType,
@@ -5478,7 +5370,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Note that <code>AdaptationEvents</code> are not fired for manual track
    * selections.
    *
-   * @param {shaka.extern.TextTrack} track
+   * @param {shaka.extern.Track} track
    * @export
    */
   selectTextTrack(track) {
@@ -5513,33 +5405,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const selectSrcEqualsMode = () => {
       if (this.video_ && this.video_.textTracks) {
         const textTracks = this.getFilteredTextTracks_();
+        const oldTrack = textTracks.find((textTrack) =>
+          textTrack.mode !== 'disabled');
         const newTrack = textTracks.find((textTrack) =>
           shaka.util.StreamUtils.html5TrackId(textTrack) === track.id);
         if (!newTrack) {
           shaka.log.error('No track with id', track.id);
           return;
         }
-        if (this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer) {
-          for (const texTrack of textTracks) {
-            const mode = texTrack === newTrack ?
-                this.isTextVisible_ ? 'showing' : 'hidden' :
-                'disabled';
-            if (texTrack.mode !== mode) {
-              texTrack.mode = mode;
-            }
+        if (oldTrack !== newTrack) {
+          if (oldTrack) {
+            oldTrack.mode = 'disabled';
+            this.loadEventManager_.unlisten(oldTrack, 'cuechange');
+            this.textDisplayer_.remove(0, Infinity);
           }
-        } else {
-          const oldTrack = textTracks.find((textTrack) =>
-            textTrack.mode !== 'disabled');
-          if (oldTrack !== newTrack) {
-            if (oldTrack) {
-              oldTrack.mode = 'disabled';
-              this.loadEventManager_.unlisten(oldTrack, 'cuechange');
-              this.textDisplayer_.remove(0, Infinity);
-            }
-            if (newTrack) {
-              this.enableNativeTrack_(newTrack);
-            }
+          if (newTrack) {
+            this.enableNativeTrack_(newTrack);
           }
         }
         this.onTextChanged_();
@@ -5693,9 +5574,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       this.updateAbrManagerVariants_();
     };
     const selectSrcEqualsMode = () => {
-      if (!track.originalAudioId) {
-        return;
-      }
       if (this.video_ && this.video_.audioTracks) {
         // Safari's native HLS won't let you choose an explicit variant, though
         // you can choose audio languages this way.
@@ -5818,105 +5696,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     return Array.from(audioTracksMap.values());
   }
 
-
-  /**
-   * Select a video track compatible with the current audio track.
-   * If the player has not loaded any content, this will be a no-op.
-   *
-   * @param {shaka.extern.VideoTrack} videoTrack
-   * @param {boolean=} clearBuffer
-   * @param {number=} safeMargin Optional amount of buffer (in seconds) to
-   *   retain when clearing the buffer. Useful for switching quickly
-   *   without causing a buffering event. Defaults to 0 if not provided. Can
-   *   cause hiccups on some browsers if chosen too small, e.g. The amount of
-   *   two segments is a fair minimum to consider as safeMargin value.
-   * @export
-   */
-  selectVideoTrack(videoTrack, clearBuffer = false, safeMargin = 0) {
-    const variants = this.getVariantTracks();
-    if (!variants.length) {
-      return;
-    }
-    const active = variants.find((t) => t.active);
-    if (!active) {
-      return;
-    }
-    const validVariant = variants.find((t) => {
-      return t.audioId === active.audioId &&
-          (t.videoBandwidth || t.bandwidth) == videoTrack.bandwidth &&
-          t.width == videoTrack.width &&
-          t.height == videoTrack.height &&
-          t.frameRate == videoTrack.frameRate &&
-          t.pixelAspectRatio == videoTrack.pixelAspectRatio &&
-          t.hdr == videoTrack.hdr &&
-          t.colorGamut == videoTrack.colorGamut &&
-          t.videoLayout == videoTrack.videoLayout &&
-          t.videoMimeType == videoTrack.mimeType &&
-          t.videoCodec == videoTrack.codecs;
-    });
-    if (validVariant && !validVariant.active) {
-      this.selectVariantTrack(validVariant, clearBuffer, safeMargin);
-    }
-  }
-
-
-  /**
-   * Return a list of video tracks compatible with the current audio track.
-   *
-   * @return {!Array<shaka.extern.VideoTrack>}
-   * @export
-   */
-  getVideoTracks() {
-    if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
-      return [];
-    }
-    const variants = this.getVariantTracks();
-    if (!variants.length) {
-      return [];
-    }
-    const active = variants.find((t) => t.active);
-    if (!active) {
-      return [];
-    }
-    const filteredTracks = variants.filter((t) => {
-      return t.originalAudioId === active.originalAudioId &&
-          t.audioId === active.audioId &&
-          t.audioGroupId === active.audioGroupId &&
-          t.videoCodec;
-    });
-    if (!filteredTracks.length) {
-      return [];
-    }
-
-    /** @type {!Map<string, shaka.extern.VideoTrack>} */
-    const videoTracksMap = new Map();
-    for (const track of filteredTracks) {
-      let id = track.originalVideoId;
-      if (!id && track.videoId != null) {
-        id = String(track.videoId);
-      }
-      if (!id) {
-        continue;
-      }
-      /** @type {shaka.extern.VideoTrack} */
-      const videoTrack = {
-        active: track.active,
-        bandwidth: track.videoBandwidth || track.bandwidth,
-        width: track.width,
-        height: track.height,
-        frameRate: track.frameRate,
-        pixelAspectRatio: track.pixelAspectRatio,
-        hdr: track.hdr,
-        colorGamut: track.colorGamut,
-        videoLayout: track.videoLayout,
-        mimeType: track.videoMimeType,
-        codecs: track.videoCodec,
-      };
-      videoTracksMap.set(id, videoTrack);
-    }
-    return Array.from(videoTracksMap.values());
-  }
-
   /**
    * Return a list of audio language-role combinations available.  If the
    * player has not loaded any content, this will return an empty list.
@@ -5938,13 +5717,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Return a list of text language-role combinations available.  If the player
    * has not loaded any content, this will be return an empty list.
    *
-   * <br>
-   *
-   * This API is deprecated and will be removed in version 5.0, please migrate
-   * to using `getTextTracks` and `selectTextTrack`.
-   *
    * @return {!Array<shaka.extern.LanguageRole>}
-   * @deprecated
    * @export
    */
   getTextLanguagesAndRoles() {
@@ -5972,13 +5745,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Return a list of text languages available. If the player has not loaded
    * any content, this will return an empty list.
    *
-   * <br>
-   *
-   * This API is deprecated and will be removed in version 5.0, please migrate
-   * to using `getTextTracks` and `selectTextTrack`.
-   *
    * @return {!Array<string>}
-   * @deprecated
    * @export
    */
   getTextLanguages() {
@@ -6089,15 +5856,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * language and role, and chooses a new variant if need be. If the player has
    * not loaded any content, this will be a no-op.
    *
-   * <br>
-   *
-   * This API is deprecated and will be removed in version 5.0, please migrate
-   * to using `getTextTracks` and `selectTextTrack`.
-   *
    * @param {string} language
    * @param {string=} role
    * @param {boolean=} forced
-   * @deprecated
    * @export
    */
   selectTextLanguage(language, role, forced = false) {
@@ -6247,7 +6008,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Return a list of chapters tracks.
    *
-   * @return {!Array<shaka.extern.TextTrack>}
+   * @return {!Array<shaka.extern.Track>}
    * @export
    */
   getChaptersTracks() {
@@ -6263,9 +6024,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   getChapters(language) {
-    shaka.Deprecate.deprecateFeature(5,
-        'getChapters',
-        'Please use an getChaptersAsync.');
     if (!this.externalChaptersStreams_.length) {
       return [];
     }
@@ -6296,50 +6054,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           }
         });
       }
-    }
-    return chapters;
-  }
-
-  /**
-   * This returns the list of chapters.
-   *
-   * @param {string} language
-   * @return {!Promise<!Array<shaka.extern.Chapter>>}
-   * @export
-   */
-  async getChaptersAsync(language) {
-    if (!this.externalChaptersStreams_.length) {
-      return [];
-    }
-    const LanguageUtils = shaka.util.LanguageUtils;
-    const inputLanguage = LanguageUtils.normalize(language);
-    const chapterStreams = this.externalChaptersStreams_
-        .filter((c) => LanguageUtils.normalize(c.language) == inputLanguage);
-    if (!chapterStreams.length) {
-      return [];
-    }
-    const chapters = [];
-    const uniqueChapters = new Set();
-    for (const chapterStream of chapterStreams) {
-      if (!chapterStream.segmentIndex) {
-        // eslint-disable-next-line no-await-in-loop
-        await chapterStream.createSegmentIndex();
-      }
-      chapterStream.segmentIndex.forEachTopLevelReference((ref) => {
-        const title = ref.getUris()[0];
-        const id = ref.startTime + '-' + ref.endTime + '-' + title;
-        /** @type {shaka.extern.Chapter} */
-        const chapter = {
-          id,
-          title,
-          startTime: ref.startTime,
-          endTime: ref.endTime,
-        };
-        if (!uniqueChapters.has(id)) {
-          chapters.push(chapter);
-          uniqueChapters.add(id);
-        }
-      });
     }
     return chapters;
   }
@@ -6461,10 +6175,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // would start at the live edge, but we don't have that yet, so return
       // the current date & time.
       return new Date();
-    } else if (this.startTime_ instanceof Date) {
-      // A specific start time as a Date has been requested.  Return it without
-      // any modification.
-      return this.startTime_;
     } else {
       // A specific start time has been requested.  This is what Playhead will
       // use once it is created.
@@ -6635,53 +6345,35 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         this.drmEngine_ ? this.drmEngine_.getLicenseTime() : NaN;
     this.stats_.setLicenseTime(licenseSeconds);
 
-    // Resolution fallback
-    this.stats_.setResolution(
-        /* width= */ element.videoWidth || NaN,
-        /* height= */ element.videoHeight || NaN);
+    if (this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE) {
+      // Event through we are loaded, it is still possible that we don't have a
+      // variant yet because we set the load mode before we select the first
+      // variant to stream.
+      const variant = this.streamingEngine_.getCurrentVariant();
+      const textStream = this.streamingEngine_.getCurrentTextStream();
 
-    this.stats_.setCodecs('');
-
-    if (this.isLive()) {
-      // Apple's native HLS gives us getStartDate(), which is only available
-      // if EXT-X-PROGRAM-DATETIME is in the playlist.
-      if (this.getPresentationStartTimeAsDate() != null) {
-        const latency = this.getLiveLatency() || 0;
-        this.stats_.setLiveLatency(latency / 1000);
-      }
-    }
-
-    const variants = this.getVariantTracks();
-    const variant = variants.find((t) => t.active);
-    const textTracks = this.getTextTracks();
-    const textTrack = textTracks.find((t) => t.active);
-    if (variant) {
-      if (variant.bandwidth) {
+      if (variant) {
         const rate = this.playRateController_ ?
            this.playRateController_.getRealRate() : 1;
         const variantBandwidth = rate * variant.bandwidth;
         let currentStreamBandwidth = variantBandwidth;
-        if (textTrack && textTrack.bandwidth) {
-          currentStreamBandwidth += (rate * textTrack.bandwidth);
+        if (textStream && textStream.bandwidth) {
+          currentStreamBandwidth += (rate * textStream.bandwidth);
         }
         this.stats_.setCurrentStreamBandwidth(currentStreamBandwidth);
       }
-      if (variant.width && variant.height) {
-        this.stats_.setResolution(
-            /* width= */ variant.width || NaN,
-            /* height= */ variant.height || NaN);
-      }
-      let codecs = variant.codecs;
-      if (textTrack) {
-        codecs += ',' + (textTrack.codecs || textTrack.mimeType);
-      }
-      if (codecs) {
-        this.stats_.setCodecs(codecs);
-      }
-    }
 
-    if (this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE &&
-        !this.isRemotePlayback()) {
+      if (variant && variant.video) {
+        this.stats_.setResolution(
+            /* width= */ variant.video.width || NaN,
+            /* height= */ variant.video.height || NaN);
+      }
+
+      if (this.isLive()) {
+        const latency = this.getLiveLatency() || 0;
+        this.stats_.setLiveLatency(latency / 1000);
+      }
+
       if (this.manifest_) {
         this.stats_.setManifestPeriodCount(this.manifest_.periodCount);
         this.stats_.setManifestGapCount(this.manifest_.gapCount);
@@ -6698,6 +6390,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
       this.stats_.addBytesDownloaded(NaN);
+      this.stats_.setResolution(
+          /* width= */ element.videoWidth || NaN,
+          /* height= */ element.videoHeight || NaN);
     }
 
     return this.stats_.getBlob();
@@ -6717,7 +6412,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string=} codec
    * @param {string=} label
    * @param {boolean=} forced
-   * @return {!Promise<shaka.extern.TextTrack>}
+   * @return {!Promise<shaka.extern.Track>}
    * @export
    */
   async addTextTrackAsync(uri, language, kind, mimeType, codec, label,
@@ -6749,15 +6444,25 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
-      if (forced && shaka.util.Platform.isApple()) {
+      if (forced) {
         // See: https://github.com/whatwg/html/issues/4472
         kind = 'forced';
       }
-      const trackNode = await this.addSrcTrackElement_(uri, language, kind,
-          mimeType, label || '', adCuePoints);
-      if (trackNode.track) {
+      await this.addSrcTrackElement_(uri, language, kind, mimeType, label || '',
+          adCuePoints);
+
+      const LanguageUtils = shaka.util.LanguageUtils;
+      const languageNormalized = LanguageUtils.normalize(language);
+
+      const textTracks = this.getTextTracks();
+      const srcTrack = textTracks.find((t) => {
+        return LanguageUtils.normalize(t.language) == languageNormalized &&
+            t.label == (label || '') &&
+            t.kind == kind;
+      });
+      if (srcTrack) {
         this.onTracksChanged_();
-        return shaka.util.StreamUtils.html5TextTrackToTrack(trackNode.track);
+        return srcTrack;
       }
       // This should not happen, but there are browser implementations that may
       // not support the Track element.
@@ -6859,7 +6564,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {string} uri
    * @param {string=} mimeType
-   * @return {!Promise<shaka.extern.ImageTrack>}
+   * @return {!Promise<shaka.extern.Track>}
    * @export
    */
   async addThumbnailsTrack(uri, mimeType) {
@@ -7020,7 +6725,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {string} uri
    * @param {string} language
    * @param {string=} mimeType
-   * @return {!Promise<shaka.extern.TextTrack>}
+   * @return {!Promise<shaka.extern.Track>}
    * @export
    */
   async addChaptersTrack(uri, language, mimeType) {
@@ -7206,7 +6911,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     this.video_.appendChild(trackElement);
-    this.externalSrcEqualsTextTracks_.push(trackElement);
     return trackElement;
   }
 
@@ -7411,7 +7115,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // TextDisplay factory must capture a reference to "this".
     config.textDisplayFactory = () => {
       // On iOS where the Fullscreen API is not available we prefer
-      // NativeTextDisplayer because it works with the Fullscreen API of the
+      // SimpleTextDisplayer because it works with the Fullscreen API of the
       // video element itself.
       const Platform = shaka.util.Platform;
       if (this.videoContainer_ &&
@@ -7419,8 +7123,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         return new shaka.text.UITextDisplayer(
             this.video_, this.videoContainer_);
       } else {
-        if ('track' in document.createElement('track')) {
-          return new shaka.text.NativeTextDisplayer(this);
+        if ('addTextTrack' in this.video_) {
+          return new shaka.text.SimpleTextDisplayer(
+              this.video_, shaka.Player.TextTrackLabel);
         } else {
           shaka.log.warning('Text tracks are not supported by the ' +
                             'browser, disabling.');
@@ -8227,7 +7932,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   switchHtml5Track_(track) {
-    const StreamUtils = shaka.util.StreamUtils;
     goog.asserts.assert(this.video_ && this.video_.audioTracks,
         'Video and video.audioTracks should not be null!');
     const audioTracks = Array.from(this.video_.audioTracks);
@@ -8246,28 +7950,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       currentTrack.enabled = false;
     }
 
-    const videoTrack = this.getActiveHtml5VideoTrack_();
-
     const oldTrack =
-        StreamUtils.html5TrackToShakaTrack(currentTrack, videoTrack);
-    const newTrack = StreamUtils.html5TrackToShakaTrack(track, videoTrack);
+      shaka.util.StreamUtils.html5AudioTrackToTrack(currentTrack);
+    const newTrack =
+      shaka.util.StreamUtils.html5AudioTrackToTrack(track);
     // Dispatch a 'variantchanged' event
     this.onVariantChanged_(oldTrack, newTrack);
 
     // Dispatch a 'audiotrackschanged' event if necessary
     this.checkAudioTracksChanged_(oldTrack, newTrack);
-  }
-
-  /**
-   * @return {VideoTrack}
-   * @private
-   */
-  getActiveHtml5VideoTrack_() {
-    if (this.video_ && this.video_.videoTracks) {
-      const videoTracks = Array.from(this.video_.videoTracks);
-      return videoTracks.find((t) => t.selected);
-    }
-    return null;
   }
 
   /**
@@ -8683,11 +8374,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @param {string} name
    * @param {string} url
-   * @return {!Promise<void>}
    * @export
    */
-  addFont(name, url) {
-    return shaka.util.Dom.addFont(name, url);
+  async addFont(name, url) {
+    if ('fonts' in document && 'FontFace' in window ) {
+      await document.fonts.ready;
+      if (!('entries' in document.fonts)) {
+        return;
+      }
+      const fontFaceSetIteratorToArray = (target) => {
+        const iterable = target.entries();
+        const results = [];
+        let iterator = iterable.next();
+        while (iterator.done === false) {
+          results.push(iterator.value);
+          iterator = iterable.next();
+        }
+        return results;
+      };
+      for (const fontFace of fontFaceSetIteratorToArray(document.fonts)) {
+        if (fontFace.family == name && fontFace.display == 'swap') {
+          // Font already loaded.
+          return;
+        }
+      }
+      const fontFace = new FontFace(name, `url(${url})`, {display: 'swap'});
+      document.fonts.add(fontFace);
+    }
   }
 
   /**
@@ -9000,7 +8713,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   /**
    * Get the normalized languages for a group of tracks.
    *
-   * @param {!Array<?(shaka.extern.Track|shaka.extern.TextTrack)>} tracks
+   * @param {!Array<?shaka.extern.Track>} tracks
    * @return {!Set<string>}
    * @private
    */
@@ -9022,7 +8735,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Get all permutations of normalized languages and role for a group of
    * tracks.
    *
-   * @param {!Array<?(shaka.extern.Track|shaka.extern.TextTrack)>} tracks
+   * @param {!Array<?shaka.extern.Track>} tracks
    * @return {!Array<shaka.extern.LanguageRole>}
    * @private
    */
@@ -9032,8 +8745,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @type {!Map<string, !Map<string, string>>} */
     const languageRoleToLabel = new Map();
 
-    for (let i = 0; i < tracks.length; i++) {
-      const track = /** @type {shaka.extern.Track} */(tracks[i]);
+    for (const track of tracks) {
       let language = 'und';
       let roles = [];
 
@@ -9240,7 +8952,7 @@ shaka.Player.TYPICAL_BUFFERING_THRESHOLD_ = 0.5;
  * @export
  */
 // eslint-disable-next-line no-useless-concat
-shaka.Player.version = 'v4.14.0' + '-uncompiled';  // x-release-please-version
+shaka.Player.version = 'v4.14.10' + '-uncompiled';  // x-release-please-version
 
 // Initialize the deprecation system using the version string we just set
 // on the player.


### PR DESCRIPTION
`getVariantTracks` is used to get the current audioTracks for HLS and DASH  manifests with local playback support.  However, this method currently returns all audiotracks for all video tracks in the manifest. This fix adds a filter which returns all audio tracks for the current/active video track.