### PR TITLE
fix: Get audio and text tracks by videoId or active track

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -91,6 +91,7 @@ Juliane Holzt <juliane@box.fqdn.org>
 Jun Hong Chong <chongjunhong@gmail.com>
 Jürgen Kartnaller <kartnaller@lovelysystems.com>
 Justin Swaney <justin.mark.swaney@gmail.com>
+Kaniu Ndungu <kaniughos@gmail.com>
 Konstantin Grushetsky <github@grushetsky.net>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Leo Antunes <leo@costela.net>

--- a/lib/player.js
+++ b/lib/player.js
@@ -626,6 +626,7 @@ goog.requireType('shaka.media.PresentationTimeline');
  */
 
 
+
 /**
  * @summary The main player object for Shaka Player.
  *
@@ -5155,6 +5156,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.trickPlayEventManager_.removeAll();
   }
 
+ /**
+  * @typedef {object} VariantTracksFilter
+  * @property {number=} videoId - The name property.
+  * @property {boolean=} activeVideo - The value property.
+  * @exportDoc
+ */
   /**
    * Return a list of variant tracks that can be switched to.
    *
@@ -5165,10 +5172,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * track with this videoId or is the current active video when activeVideo
    * is set to true. Filter for videoId supersedes the activeVideo filter.
    *
-   * @param {{ videoId: number, activeVideo: boolean }} [filter]
+   * @param {{ videoId : (undefined | number) , activeVideo: (undefined | boolean) }?=} filter
    * @return {!Array<shaka.extern.Track>}
    * @export
    */
+
   getVariantTracks(filter) {
     if (this.manifest_ && !this.isRemotePlayback()) {
       const currentVariant = this.streamingEngine_ ?

--- a/lib/player.js
+++ b/lib/player.js
@@ -626,7 +626,6 @@ goog.requireType('shaka.media.PresentationTimeline');
  */
 
 
-
 /**
  * @summary The main player object for Shaka Player.
  *
@@ -5156,12 +5155,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.trickPlayEventManager_.removeAll();
   }
 
- /**
-  * @typedef {object} VariantTracksFilter
-  * @property {number=} videoId - The name property.
-  * @property {boolean=} activeVideo - The value property.
-  * @exportDoc
- */
   /**
    * Return a list of variant tracks that can be switched to.
    *
@@ -5172,7 +5165,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * track with this videoId or is the current active video when activeVideo
    * is set to true. Filter for videoId supersedes the activeVideo filter.
    *
-   * @param {{ videoId : (undefined | number) , activeVideo: (undefined | boolean) }?=} filter
+   * @param {{
+   * videoId : (undefined | number),
+   * activeVideo: (undefined | boolean) }?=} filter
    * @return {!Array<shaka.extern.Track>}
    * @export
    */

--- a/lib/player.js
+++ b/lib/player.js
@@ -5161,13 +5161,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * <p>
    * If the player has not loaded content, this will return an empty list.
    * <p>
-   * Uses videoIdFilter to return audio and text tracks for that video track. 
-   * 
-   * @param {?number=} videoIdFilter
+   * Optional: Uses a filter to return audio and text tracks for a video
+   * track with this videoId or is the current active video when activeVideo
+   * is set to true. Filter for videoId supersedes the activeVideo filter.
+   *
+   * @param {{ videoId: number, activeVideo: boolean }} [filter]
    * @return {!Array<shaka.extern.Track>}
    * @export
    */
-  getVariantTracks(videoIdFilter) {
+  getVariantTracks(filter) {
     if (this.manifest_ && !this.isRemotePlayback()) {
       const currentVariant = this.streamingEngine_ ?
           this.streamingEngine_.getCurrentVariant() : null;
@@ -5175,7 +5177,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const tracks = [];
 
       let activeTracks = 0;
-
+      let filterVideoId = null;
       // Convert each variant to a track.
       for (const variant of this.manifest_.variants) {
         if (!shaka.util.StreamUtils.isPlayable(variant)) {
@@ -5192,27 +5194,33 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
         if (track.active) {
           activeTracks++;
+          if (filter && filter.activeVideo === true) {
+            filterVideoId = track.videoId;
+          }
         }
 
         tracks.push(track);
       }
+      // filter.videoId supersedes filter.activeVideo
+      filterVideoId = filter && filter.videoId !== undefined ?
+       filter.videoId : filterVideoId;
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
+
       // This filter was added to remove tracks that are not associated
       // with the videoIdFilter track. Refer to issue #8588
-      if (!videoIdFilter) {
+      if (!filterVideoId) {
         return tracks;
       } else {
         const filteredTracks = [];
         for (const track of tracks) {
-          if (track.videoId === videoIdFilter) {
+          if (track.videoId === filterVideoId) {
             filteredTracks.push(track);
           }
         }
         return filteredTracks;
       }
-
     } else if (this.video_ && this.video_.audioTracks) {
       const videoTrack = this.getActiveHtml5VideoTrack_();
       // Safari's native HLS always shows a single element in videoTracks.

--- a/lib/player.js
+++ b/lib/player.js
@@ -5160,15 +5160,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * <p>
    * If the player has not loaded content, this will return an empty list.
+   * <p>
+   * Uses videoIdFilter to return audio and text tracks for that video track. 
+   * 
+   * @param {?number=} videoIdFilter
    * @return {!Array<shaka.extern.Track>}
    * @export
    */
-  getVariantTracks() {
-    let videoIdFilter = undefined;
-    if (arguments.length > 0 &&  typeof arguments[0] === 'number' ){
-      videoIdFilter = arguments[0]
-    }
-
+  getVariantTracks(videoIdFilter) {
     if (this.manifest_ && !this.isRemotePlayback()) {
       const currentVariant = this.streamingEngine_ ?
           this.streamingEngine_.getCurrentVariant() : null;
@@ -5200,7 +5199,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
-  
+      // This filter was added to remove tracks that are not associated
+      // with the videoIdFilter track. Refer to issue #8588
       if (!videoIdFilter) {
         return tracks;
       } else {
@@ -5234,31 +5234,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return [];
     }
   }
-
-    /**
-   * Return a list of variant tracks that can be switched to.
-   * Filters getVariantTracks results by a videoId to limit
-   * results to audio, text tracks and a video track.
-   * <p>
-   * If the player has not loaded content, this will return an empty list.
-   * @param {number|undefined} videoId
-   * @return {!Array<shaka.extern.Track>}
-   * @export
-   */
-    getVariantTracksByVideoId(videoId) {
-      const tracks = this.getVariantTracks();
-      const filteredTracks = [];
-      if (!videoId) {
-        return tracks;
-      }else{
-        for (const track of tracks) {
-          if (track.videoId === videoId) {
-            filteredTracks.push(track);
-          }
-        } 
-      }
-      return filteredTracks;
-    }
 
   /**
    * Return a list of text tracks that can be switched to.

--- a/lib/player.js
+++ b/lib/player.js
@@ -5164,6 +5164,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   getVariantTracks() {
+    let videoIdFilter = undefined;
+    if (arguments.length > 0 &&  typeof arguments[0] === 'number' ){
+      videoIdFilter = arguments[0]
+    }
+
     if (this.manifest_ && !this.isRemotePlayback()) {
       const currentVariant = this.streamingEngine_ ?
           this.streamingEngine_.getCurrentVariant() : null;
@@ -5195,8 +5200,19 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
-      
-      return tracks;
+  
+      if (!videoIdFilter) {
+        return tracks;
+      } else {
+        const filteredTracks = [];
+        for (const track of tracks) {
+          if (track.videoId === videoIdFilter) {
+            filteredTracks.push(track);
+          }
+        }
+        return filteredTracks;
+      }
+
     } else if (this.video_ && this.video_.audioTracks) {
       const videoTrack = this.getActiveHtml5VideoTrack_();
       // Safari's native HLS always shows a single element in videoTracks.

--- a/lib/player.js
+++ b/lib/player.js
@@ -5160,7 +5160,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * <p>
    * If the player has not loaded content, this will return an empty list.
-   *
    * @return {!Array<shaka.extern.Track>}
    * @export
    */
@@ -5196,7 +5195,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       goog.asserts.assert(activeTracks <= 1,
           'It should only have one active track');
-
+      
       return tracks;
     } else if (this.video_ && this.video_.audioTracks) {
       const videoTrack = this.getActiveHtml5VideoTrack_();
@@ -5219,6 +5218,31 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return [];
     }
   }
+
+    /**
+   * Return a list of variant tracks that can be switched to.
+   * Filters getVariantTracks results by a videoId to limit
+   * results to audio, text tracks and a video track.
+   * <p>
+   * If the player has not loaded content, this will return an empty list.
+   * @param {number|undefined} videoId
+   * @return {!Array<shaka.extern.Track>}
+   * @export
+   */
+    getVariantTracksByVideoId(videoId) {
+      const tracks = this.getVariantTracks();
+      const filteredTracks = [];
+      if (!videoId) {
+        return tracks;
+      }else{
+        for (const track of tracks) {
+          if (track.videoId === videoId) {
+            filteredTracks.push(track);
+          }
+        } 
+      }
+      return filteredTracks;
+    }
 
   /**
    * Return a list of text tracks that can be switched to.

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2286,6 +2286,11 @@ describe('Player', () => {
       expect(player.getVideoTracks()).toEqual(videoTracks);
       expect(player.getTextTracks()).toEqual(textTracks);
       expect(player.getImageTracks()).toEqual(imageTracks);
+      //can filter getVariantTracks by videoId
+      expect(player.getVariantTracks(1)).toEqual(variantTracks.filter((t) => t.videoId===1));
+      expect(player.getVariantTracks(2)).toEqual(variantTracks.filter((t) => t.videoId===2));
+      //return no variants 
+      expect(player.getVariantTracks(20000)).toEqual([]); 
     });
 
     it('returns empty arrays before tracks can be determined', async () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2296,10 +2296,10 @@ describe('Player', () => {
       // get current active video track's related tracks
       expect(player.getVariantTracks({activeVideo: true})).toEqual(variantTracks
           .filter((t) => t.videoId === 1));
-      // this is equivaluent to no filter
+      // this is equivalent to no filter
       expect(player.getVariantTracks({activeVideo: false}))
           .toEqual(variantTracks);
-      // this videoIddoesnot exist , therefore return empty variants
+      // this videoId does not exist, therefore return empty variants
       expect(player.getVariantTracks({videoId: 2000})).toEqual([]);
     });
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2286,14 +2286,21 @@ describe('Player', () => {
       expect(player.getVideoTracks()).toEqual(videoTracks);
       expect(player.getTextTracks()).toEqual(textTracks);
       expect(player.getImageTracks()).toEqual(imageTracks);
-      //can filter getVariantTracks by videoId
+      // can filter getVariantTracks by videoId or activeVideo boolean
       expect(player.getVariantTracks(null)).toEqual(variantTracks);
-      expect(player.getVariantTracks(1)).toEqual(variantTracks
-        .filter((t) => t.videoId===1));
-      expect(player.getVariantTracks(2)).toEqual(variantTracks
-        .filter((t) => t.videoId===2));
-      //return no variants 
-      expect(player.getVariantTracks(20000)).toEqual([]); 
+      // get specific videoId related tracks
+      expect(player.getVariantTracks({videoId: 1})).toEqual(variantTracks
+          .filter((t) => t.videoId===1));
+      expect(player.getVariantTracks({videoId: 2})).toEqual(variantTracks
+          .filter((t) => t.videoId===2));
+      // get current active video track's related tracks
+      expect(player.getVariantTracks({activeVideo: true})).toEqual(variantTracks
+          .filter((t) => t.videoId === 1));
+      // this is equivaluent to no filter
+      expect(player.getVariantTracks({activeVideo: false}))
+          .toEqual(variantTracks);
+      // this videoIddoesnot exist , therefore return empty variants
+      expect(player.getVariantTracks({videoId: 2000})).toEqual([]);
     });
 
     it('returns empty arrays before tracks can be determined', async () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -2287,8 +2287,11 @@ describe('Player', () => {
       expect(player.getTextTracks()).toEqual(textTracks);
       expect(player.getImageTracks()).toEqual(imageTracks);
       //can filter getVariantTracks by videoId
-      expect(player.getVariantTracks(1)).toEqual(variantTracks.filter((t) => t.videoId===1));
-      expect(player.getVariantTracks(2)).toEqual(variantTracks.filter((t) => t.videoId===2));
+      expect(player.getVariantTracks(null)).toEqual(variantTracks);
+      expect(player.getVariantTracks(1)).toEqual(variantTracks
+        .filter((t) => t.videoId===1));
+      expect(player.getVariantTracks(2)).toEqual(variantTracks
+        .filter((t) => t.videoId===2));
       //return no variants 
       expect(player.getVariantTracks(20000)).toEqual([]); 
     });


### PR DESCRIPTION
`getVariantTracks` is used to get the current audioTracks for HLS and DASH  manifests with local playback support.  However, this method currently returns all audiotracks for all video tracks in the manifest. This fix adds a filter which returns all audio and text tracks for a specific videoId or current/active video track.
This filter will be used in extended systems such casting which requires a narrow view of available tracks.

[Fixing Issue: 8588](https://github.com/shaka-project/shaka-player/issues/8588)